### PR TITLE
Bugfix naming error on bp product controller

### DIFF
--- a/app/controllers/spree/bp_product_controller.rb
+++ b/app/controllers/spree/bp_product_controller.rb
@@ -1,4 +1,4 @@
-class BpProductController < AppicationController
+class BpProductController < ApplicationController
   def create
     BpProduct.create bp_products_params
   end


### PR DESCRIPTION
There is a naming error on bp product controller. Don't know why didn't break before 
